### PR TITLE
Lower minSdk to 29 (Android 10) — closes #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [1.1.0] - 2026-07-09
+## [Unreleased]
+
+### Changed
+- **Lower `minSdk` to 29 (Android 10)** — Issue #2. The app now supports Android 10+ instead of requiring Android 14+. Backward-compatible screenshot detection continues to use `MediaStore` + `ContentObserver`; the foreground service now only requests the `specialUse` type on API 34+ and falls back to no type on older levels.
+
+### Fixed
+- Storage-permission trap on Android 10-12: the runtime check and request now use `READ_EXTERNAL_STORAGE` below API 33 (via `StoragePermissions`) instead of always requesting `READ_MEDIA_IMAGES`, which does not exist below 33.
+- Foreground-service crash on API 29-33: `startForeground` only passes `FOREGROUND_SERVICE_TYPE_SPECIAL_USE` on API 34+.
+
+### Notes
+- Automatic background cleanup requires Android 11+ (All-Files access). On Android 10, detection and manual/notification deletes still work; silent background deletion is intentionally disabled.
 
 ### Added
 - **Janitor On/Off toggle** — Long-press the **Pending** stat card to toggle the Janitor background monitor on or off. When off, a Material 3 Expressive red **"OFF" stamp** appears on the Pending card, the background detection service is stopped (the squiggly rotating indicator in **Next Scheduled Cleanup** also freezes), and a snackbar confirms the state. The choice persists across restarts and reboots. Implemented via `HomeViewModel.toggleJanitor()`, `SettingsRepository`, `SsJanitorApp.stopDetectionService()`, the new `OffBadge`, and an `isActive` flag on `NextCleanupBanner`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="screenshots/app_icon.png" alt="ssJanitor" width="96" height="96"/>
   <h1>ssJanitor</h1>
-  <p>Minimal Android 14+ screenshot management utility</p>
+  <p>Minimal Android 10+ screenshot management utility</p>
   <p>
     <strong>Kotlin</strong> · <strong>Jetpack Compose</strong> · <strong>Material 3</strong>
   </p>
@@ -68,7 +68,7 @@ ssJanitor monitors newly created screenshots, lets you archive or delete them th
 
 1. Open the project in Android Studio.
 2. Sync Gradle (uses version catalog at `gradle/libs.versions.toml`).
-3. Build and run on a device running **Android 14+** (min SDK 34).
+3. Build and run on a device running **Android 10+** (min SDK 29). Automatic background cleanup requires Android 11+ (All-Files access); detection and manual deletes work on Android 10+.
 
 No API keys, no cloud services, no configuration required.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 
     defaultConfig {
         applicationId = "dev.sj010.ssjanitor"
-        minSdk = 34
+        minSdk = 29
         targetSdk = 36
         versionCode = 8
         versionName = "1.1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />

--- a/app/src/main/java/dev/sj010/ssjanitor/core/permissions/StoragePermissions.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/core/permissions/StoragePermissions.kt
@@ -1,0 +1,30 @@
+package dev.sj010.ssjanitor.core.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Centralizes the storage-permission decision so the runtime *check* and the
+ * *request* can never diverge (they previously both hardcoded
+ * [Manifest.permission.READ_MEDIA_IMAGES], which does not exist below API 33
+ * and left API 29-32 devices stuck in a permanent "Permissions Required" state).
+ *
+ * - API 33+ (TIRAMISU): [Manifest.permission.READ_MEDIA_IMAGES]
+ * - API 29-32: [Manifest.permission.READ_EXTERNAL_STORAGE]
+ */
+object StoragePermissions {
+
+    fun requiredStoragePermission(): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_IMAGES
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+
+    fun hasStoragePermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, requiredStoragePermission()) ==
+            PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/dev/sj010/ssjanitor/service/ScreenshotDetectionService.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/service/ScreenshotDetectionService.kt
@@ -25,7 +25,7 @@ class ScreenshotDetectionService : Service() {
         startForeground(
             AppConstants.NOTIFICATION_SERVICE_ID,
             nm.createForegroundServiceNotification(),
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE else 0
         )
         detector.startDetector()

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import dev.sj010.ssjanitor.core.permissions.StoragePermissions
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -72,19 +73,19 @@ fun HomeScreen(
     }
 
     var hasStoragePermission by remember {
-        mutableStateOf(
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.READ_MEDIA_IMAGES
-            ) == PackageManager.PERMISSION_GRANTED
-        )
+        mutableStateOf(StoragePermissions.hasStoragePermission(context))
     }
 
     var isAllFilesManager by remember {
         mutableStateOf(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 android.os.Environment.isExternalStorageManager()
-            } else true
+            } else {
+                // All-Files access does not exist below Android 11 (API 30), and
+                // automatic background cleanup is intentionally disabled there (see
+                // ScreenshotCleanupWorker), so there is nothing to request.
+                true
+            }
         )
     }
 
@@ -243,7 +244,7 @@ fun HomeScreen(
                     list.add(Manifest.permission.POST_NOTIFICATIONS)
                 }
                 if (!hasStoragePermission) {
-                    list.add(Manifest.permission.READ_MEDIA_IMAGES)
+                    list.add(StoragePermissions.requiredStoragePermission())
                 }
                 if (list.isNotEmpty()) {
                     permissionLauncher.launch(list.toTypedArray())

--- a/app/src/main/java/dev/sj010/ssjanitor/worker/ScreenshotCleanupWorker.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/worker/ScreenshotCleanupWorker.kt
@@ -1,6 +1,7 @@
 package dev.sj010.ssjanitor.worker
 
 import android.content.Context
+import android.os.Build
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import dev.sj010.ssjanitor.SsJanitorApp
@@ -20,18 +21,25 @@ class ScreenshotCleanupWorker(
         return try {
             val archived = repository.getArchivedForCleanup()
             if (archived.isNotEmpty()) {
-                val nm = ScreenshotNotificationManager(applicationContext)
-                val deleted = repository.deleteScreenshotsDirectly(
-                    applicationContext,
-                    archived.map { it.uri }
-                )
-                if (deleted.isNotEmpty()) {
-                    repository.markAsDeleted(deleted)
-                    nm.showAutoCleanupNotification(deleted.size)
-                }
-                val failed = archived.size - deleted.size
-                if (failed > 0) {
-                    nm.showCleanupNotification(failed)
+                // Silent (user-consent-free) deletion requires All-Files access,
+                // which only exists on Android 11+ (API 30). On API 29 there is no
+                // mechanism for background deletion, so we intentionally skip the
+                // worker there — manual/notification deletes via createDeleteRequest
+                // still work on every supported level.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val nm = ScreenshotNotificationManager(applicationContext)
+                    val deleted = repository.deleteScreenshotsDirectly(
+                        applicationContext,
+                        archived.map { it.uri }
+                    )
+                    if (deleted.isNotEmpty()) {
+                        repository.markAsDeleted(deleted)
+                        nm.showAutoCleanupNotification(deleted.size)
+                    }
+                    val failed = archived.size - deleted.size
+                    if (failed > 0) {
+                        nm.showCleanupNotification(failed)
+                    }
                 }
             }
             val app = applicationContext as SsJanitorApp

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,8 +18,8 @@
 
 ## Android Version Support
 
-- **Android 14+** (min SDK 34)
-- Older versions intentionally unsupported to simplify storage handling, permission management, background execution, and maintenance.
+- **Android 10+** (min SDK 29)
+- Automatic background cleanup requires Android 11+ (All-Files access). On Android 10, detection and manual/notification deletes work, but silent background deletion is unavailable (All-Files access does not exist below API 30).
 
 ## MVP Scope (v1.0)
 
@@ -77,7 +77,7 @@ The app should feel like a native Android utility.
 | Notification actions | ❌ Not tested |
 | Cleanup reliability | ❌ Not tested |
 | Battery impact | ❌ Not tested |
-| Android 14 behavior | ✅ Verified |
+| Android 10+ behavior (API 29-36) | ⚠️ Verify on emulator matrix |
 | Process death recovery | ❌ Not tested |
 
 ## Building

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@
 
 Detect newly created screenshots using `MediaStore` and `ContentObserver`.
 
-- Supports Android 14+ scoped storage model.
+- Supports Android 10+ scoped storage model. Detection works on Android 10+; automatic background cleanup requires Android 11+ (All-Files access).
 - Event-driven architecture — no continuous polling.
 - **URI-based detection** — queries by content URI ID instead of bulk-scanning latest images, minimizing read overhead.
 - **Cold-start handling** — `performInitialScan()` catches screenshots taken during app startup; `scanLatestScreenshots()` fallback handles edge cases where `onChange` fires before MediaStore creates the row.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Minimal Android 14+ screenshot management utility — archive, keep, or delete screenshots with a single tap.
+Minimal Android 10+ screenshot management utility — archive, keep, or delete screenshots with a single tap.


### PR DESCRIPTION
## Summary\nImplements issue #2: lower minSdk from 34 (Android 14) to 29 (Android 10) so the app supports older devices.\n\n### Changes\n- minSdk 34 → 29 (app/build.gradle.kts)\n- Manifest: add READ_EXTERNAL_STORAGE / WRITE_EXTERNAL_STORAGE (maxSdk=32); keep specialUse + subtype (tolerated on older platforms, used only on API 34+)\n- ScreenshotDetectionService: only pass FOREGROUND_SERVICE_TYPE_SPECIAL_USE on API 34+ (previously >= Q, which crashed the FGS on API 29–33)\n- New StoragePermissions helper: SDK-aware storage-permission check + request (fixes the permanent 'Permissions Required' trap on API 29–32 where READ_MEDIA_IMAGES does not exist)\n- ScreenshotCleanupWorker: gate silent background deletion to API 30+ (All-Files access); manual/notification deletes via createDeleteRequest still work on 29+\n- HomeScreen: use the StoragePermissions helper; isAllFilesManager is now honest below API 30\n- Docs + CHANGELOG: reflect Android 10+ support and the API-29 auto-cleanup limitation\n\n### Verification\n- ./gradlew assembleDebug and assembleRelease both BUILD SUCCESSFUL (incl. R8 minify + lintVital)\n- Merged manifest confirms minSdkVersion=29, READ/WRITE_EXTERNAL_STORAGE, and retained specialUse\n- NOTE: runtime behavior across API 29–34 (detection, permission prompts, auto-cleanup) should still be verified on the emulator matrix per docs/development.md.\n\nCloses #2