### PR TITLE
Automate pre-release test-APK flow (Closes #5)

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,8 +1,10 @@
 name: Build APK
 
-# Lets anyone download a sideloadable APK directly from the pipeline.
-# Triggers on manual dispatch, on pushes to the feature branch, and on PRs.
-# Builds a debug-signed APK (no keystore needed in CI) and uploads it as an artifact.
+# Produces a downloadable, installable test APK for every feature/fix branch push
+# and every PR to main, as standard CI/CD practice (see issue #5).
+# - Uploads the APK as a pipeline artifact (fast download from the run).
+# - Publishes it as an automated pre-release keyed to the source branch/PR,
+#   updated in place so old test builds don't accumulate.
 
 on:
   workflow_dispatch:
@@ -15,7 +17,7 @@ on:
       - "main"
 
 permissions:
-  contents: read
+  contents: write # needed to create/update pre-release tags
 
 jobs:
   build-apk:
@@ -35,9 +37,39 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug --build-cache --parallel
 
+      - name: Determine pre-release tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            SLUG=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '_' '-')
+            echo "tag=test-${SLUG}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+
+      - name: Publish pre-release test APK
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag.outputs.tag }}
+          name: Test build ${{ steps.tag.outputs.tag }}
+          prerelease: true
+          allowUpdates: true
+          removeArtifacts: true
+          artifacts: app/build/outputs/apk/debug/app-debug.apk
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Automated **debug-signed** test APK for `${{ github.ref_name }}` (${{ github.sha }}).
+
+            Install with "Unknown sources" enabled. CI has no keystore, so this build is
+            debug-signed (same code as release; sideload-only). A release-signed variant
+            can be added later via repo secrets if desired.
+
+            Also downloadable as a pipeline artifact from the same run.


### PR DESCRIPTION
## Summary
Implements #5 — replaces the ad-hoc manual pre-release with an **automated pre-release test-APK flow** as standard CI/CD practice.

- `.github/workflows/build-apk.yml` now publishes a debug-signed test APK as a **pre-release** on every push to `feature/**`/`fix/**` and every PR to `main`, in addition to the pipeline artifact.
- Pre-release tags are keyed to the source: `test-<branch-slug>` for branch pushes, `pr-<number>` for PRs — updated in place via `allowUpdates`, so old test builds don't accumulate (clutter-free).
- Keeps the `upload-artifact` step so the APK is also downloadable straight from the run.
- Signing is debug (CI has no keystore); the pre-release body states it's debug-signed for sideloading. An optional release-signed build via repo secrets can be added later per the issue.

## Depends on #4
This PR is **stacked on `feature/issue-2-lower-minsdk-api29` (PR #4)** and must be merged **only after #4 is merged/closed first**. Once #4 lands on `main`, rebase this branch onto `main` and switch this PR's base to `main`, then merge to close #5.

Closes #5
