### PR TITLE
ci: add SDLC governance files and harden workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS
+# Define who is automatically requested for review on pull requests.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo.
+*       @ShubhamJ010
+
+# Android app source.
+/app/                       @ShubhamJ010
+
+# CI/CD pipelines and repository governance.
+/.github/                   @ShubhamJ010

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a problem with ScreenshotJanitor
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. -->
+
+## Environment
+
+- App version / build: <!-- e.g. v1.2.0 or commit hash -->
+- Android version (API level): <!-- e.g. Android 13 / API 33 -->
+- Device: <!-- e.g. Pixel 6, OnePlus 8T -->
+
+## Logs / screenshots
+
+<!-- Paste relevant logs (adb logcat) or screenshots. Remove any personal info. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for ScreenshotJanitor
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+
+<!-- A clear and concise description of what the problem is. -->
+
+## Describe the solution you'd like
+
+<!-- What you want to happen. -->
+
+## Describe alternatives you've considered
+
+<!-- Any alternative solutions or features you've thought about. -->
+
+## Additional context
+
+<!-- Screenshots, mockups, or any other context. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thanks for contributing to ScreenshotJanitor! -->
+
+## What does this PR do?
+
+<!-- Describe the changes and the motivation behind them. -->
+
+## Related issue
+
+<!-- e.g. Closes #5  (or "None" if not applicable) -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Refactor / chore / docs
+
+## How has this been tested?
+
+<!-- Describe how you verified the change (e.g. `./gradlew lint test assembleDebug`, device/API level tested). -->
+
+- [ ] `./gradlew lint`
+- [ ] `./gradlew test`
+- [ ] Manual verification on device/emulator (API level: ___)
+
+## Checklist
+
+- [ ] My code follows the project style and builds cleanly
+- [ ] I have added/updated tests where appropriate
+- [ ] I have updated `CHANGELOG.md` (for user-facing changes)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest `main` release (`v*`) | :white_check_mark: |
+| older releases            | :x:                |
+
+Only the most recent published release receives security fixes.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in ScreenshotJanitor, please **do not
+open a public issue**.
+
+Instead, report it privately using GitHub's built-in security advisories:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability** (Private Vulnerability Reporting).
+3. Provide a description, reproduction steps, and impact.
+
+You can expect an initial response within a few days. Once the issue is
+confirmed and fixed, a patched release will be published and you will be
+credited (unless you prefer to remain anonymous).
+
+## Notes on Permissions
+
+ScreenshotJanitor requests storage/photo permissions (`READ_MEDIA_IMAGES` /
+`READ_EXTERNAL_STORAGE`) and scans the device for screenshots. It does **not**
+upload, transmit, or share any user files or media off the device. File access
+is limited to local cleanup and archiving operations performed on the user's
+own device.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration
+# Keeps Gradle dependencies and GitHub Actions up to date automatically.
+version: 2
+updates:
+  # Java / Android dependencies managed via Gradle (libs.versions.toml, build.gradle)
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "build"
+
+  # GitHub Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,22 @@ name: Android CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 permissions:
   contents: read
 
+# Cancel superseded runs for the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,15 @@ on:
 permissions:
   contents: write
 
+# Never cancel an in-progress release build; group by tag instead.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Add repository governance/scaffolding and harden the existing CI/CD workflows.

### New files
- `.github/dependabot.yml` — weekly automated updates for Gradle deps and GitHub Actions
- `.github/CODEOWNERS` — automatic review routing
- `.github/SECURITY.md` — private vulnerability reporting policy (+ notes on storage permissions)
- `.github/PULL_REQUEST_TEMPLATE.md` — standardized PR template
- `.github/ISSUE_TEMPLATE/` — bug report + feature request templates

### Workflow hardening
- `ci.yml`: removed the dead `master` trigger (repo is `main`-only), added a `concurrency` group with `cancel-in-progress` and a 20-min job timeout
- `release.yml`: added a `concurrency` group (no cancel, so a release build is never interrupted) and a 30-min job timeout

## Notes
- `build-pr-test-apk.yml` is intentionally **not** touched here — it currently lives only on the `feature/issue-2-lower-minsdk-api29` branch (issue #5) and is not on `main` yet. Its equivalent polish (concurrency, drop `workflow_dispatch`) should land with that PR to avoid mixing work.

## Test plan
- Validate YAML: workflows parse and run on the PR (Android CI should pass lint + unit tests + debug build).
- No app code changed.
