### PR TITLE
perf(gesture): optimize pull-to-reveal kept screenshots gesture and compact counts (v1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.1.2] - 2026-08-11
+
+### Performance
+- **Pull-to-reveal gesture optimization** — Replaced 120Hz coroutine dispatches during touch scroll processing (`onPostScroll`/`onPreScroll`) with direct float state updates (`rawPullOffset`), eliminating input latency spikes and coroutine object allocation churn.
+- **Gesture release & layout stability** — Removed `Modifier.animateItem()` and structural height expand/collapse from `PullToKeptIndicator`, using `graphicsLayer` translation & alpha for 100% smooth 60fps spring release animations without layout jumps.
+
+### Changed
+- **Compact count formatting** — Stats cards (Pending, Archived, Kept, Cleaned) and section headers now format counts using compact `1K`, `1.5K`, `10K`, `1.2M`, `1B` notation (`formatCompactCount`).
+- **Kept stat card click action** — Tapping or long-pressing the **Kept** stat card reveals the kept screenshots list and smoothly animates the scroll position directly to the "Kept Screenshots" header.
+
 ## [1.1.1] - 2026-07-11
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         applicationId = "dev.sj010.ssjanitor"
         minSdk = 34
         targetSdk = 36
-        versionCode = 9
-        versionName = "1.1.1"
+        versionCode = 10
+        versionName = "1.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeContent.kt
@@ -166,9 +166,13 @@ fun HomeContent(
                             pullToReveal.dismissKept()
                         }
                     } else {
-                        pullToReveal.toggleShowKept()
+                        pullToReveal.showKept = true
                         coroutineScope.launch {
-                            listState.animateScrollToItem(listState.layoutInfo.totalItemsCount)
+                            kotlinx.coroutines.delay(60)
+                            val targetIndex = listState.layoutInfo.visibleItemsInfo
+                                .firstOrNull { it.key == "kept_header_inner" }?.index
+                                ?: (listState.layoutInfo.totalItemsCount - 1 - keptList.size).coerceAtLeast(0)
+                            listState.animateScrollToItem(targetIndex)
                         }
                     }
                 }
@@ -221,7 +225,7 @@ fun HomeContent(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = count.toString(),
+                            text = dev.sj010.ssjanitor.ui.screens.home.common.formatCompactCount(count),
                             style = MaterialTheme.typography.labelLarge,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeContent.kt
@@ -105,12 +105,10 @@ fun HomeContent(
     // ── Pull-to-reveal state ────────────────────────────────────────────────
     val pullToReveal = rememberPullToRevealState(keptListSize = { keptList.size })
 
-    // True once user has scrolled all the way to the bottom of pending+achieved
+    // True once user has scrolled all the way to the bottom
     val isAtBottom by remember {
         derivedStateOf {
-            val layoutInfo = listState.layoutInfo
-            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()
-            lastVisible != null && lastVisible.index >= layoutInfo.totalItemsCount - 1
+            !listState.canScrollForward
         }
     }
 
@@ -331,16 +329,13 @@ fun HomeContent(
             if (!pullToReveal.showKept && keptList.isNotEmpty()) {
                 item(key = "pull_to_kept") {
                     val pullFraction =
-                        (pullToReveal.pullOffsetAnim.value / 380f).coerceIn(0f, 1f)
-                    val isPulling = pullFraction > 0f
+                        (pullToReveal.pullOffset / 380f).coerceIn(0f, 1f)
 
                     PullToKeptIndicator(
+                        pullOffset = pullToReveal.pullOffset,
                         pullFraction = pullFraction,
                         isAtEnd = isAtBottom,
-                        isPulling = isPulling,
-                        isReleasing = pullToReveal.isReleasing,
-                        keptCount = keptList.size,
-                        modifier = Modifier.animateItem()
+                        keptCount = keptList.size
                     )
                 }
             }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/common/AnimatedCounter.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/common/AnimatedCounter.kt
@@ -13,6 +13,43 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import kotlinx.coroutines.delay
+import java.util.Locale
+
+/**
+ * Formats a count value compacting numbers 1000+ to K, M, B representation.
+ * - 0 to 999: "0", "42", "999"
+ * - 1000+: "1K", "1.5K", "10K", "1.2M", etc.
+ */
+fun formatCompactCount(count: Int): String {
+    val num = count.toLong()
+    return when {
+        num < 1000 -> num.toString()
+        num < 1_000_000 -> {
+            val k = num / 1000.0
+            if (num % 1000 == 0L || k >= 100.0) {
+                "${k.toInt()}K"
+            } else {
+                String.format(Locale.US, "%.1fK", k).replace(".0K", "K")
+            }
+        }
+        num < 1_000_000_000 -> {
+            val m = num / 1_000_000.0
+            if (num % 1_000_000 == 0L || m >= 100.0) {
+                "${m.toInt()}M"
+            } else {
+                String.format(Locale.US, "%.1fM", m).replace(".0M", "M")
+            }
+        }
+        else -> {
+            val b = num / 1_000_000_000.0
+            if (num % 1_000_000_000 == 0L || b >= 100.0) {
+                "${b.toInt()}B"
+            } else {
+                String.format(Locale.US, "%.1fB", b).replace(".0B", "B")
+            }
+        }
+    }
+}
 
 @Composable
 fun AnimatedCounter(
@@ -38,7 +75,7 @@ fun AnimatedCounter(
     }
 
     Text(
-        text = animatable.value.toInt().toString(),
+        text = formatCompactCount(animatable.value.toInt()),
         style = style,
         fontWeight = fontWeight,
         color = color,

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/common/SectionHeader.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/common/SectionHeader.kt
@@ -48,7 +48,7 @@ fun SectionHeader(
         )
         Spacer(modifier = Modifier.weight(1f))
         Text(
-            text = "$count",
+            text = formatCompactCount(count),
             style = MaterialTheme.typography.bodySmall,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.outline

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/NestedScrollPullToRevealState.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/NestedScrollPullToRevealState.kt
@@ -1,42 +1,39 @@
 package dev.sj010.ssjanitor.ui.screens.home.gesture
 
-import android.os.Build
-import android.view.HapticFeedbackConstants
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Velocity
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * Encapsulates the pull-to-reveal gesture logic for revealing "Kept" screenshots.
  *
  * Uses a rubber-band damped pull that resists harder the further you drag,
- * with haptic feedback at the threshold and a spring-back animation on release.
+ * with a spring-back animation on release.
  */
 class NestedScrollPullToRevealState(
     private val coroutineScope: CoroutineScope,
-    private val performHaptic: () -> Unit,
     private val keptListSize: () -> Int
 ) {
     var showKept by mutableStateOf(false)
 
-    val pullOffsetAnim = Animatable(0f)
+    // Direct float state updated synchronously during touch dragging to avoid 120Hz coroutine dispatch overhead
+    private var rawPullOffset by mutableFloatStateOf(0f)
 
-    private var isHapticTriggered by mutableStateOf(false)
+    // Animatable used strictly for spring-back release flings
+    private val releaseAnim = Animatable(0f)
+
     var isReleasing by mutableStateOf(false)
 
     // True once user has scrolled all the way to the bottom of pending+achieved
@@ -44,6 +41,9 @@ class NestedScrollPullToRevealState(
 
     private val pullThreshold = 380f
     private val maxPull = 520f
+
+    val pullOffset: Float
+        get() = if (isReleasing) releaseAnim.value else rawPullOffset
 
     val nestedScrollConnection: NestedScrollConnection = object : NestedScrollConnection {
         override fun onPostScroll(
@@ -56,55 +56,49 @@ class NestedScrollPullToRevealState(
                 (isAtBottomFn?.invoke() == true) && source == NestedScrollSource.UserInput
             ) {
                 val rawDelta = -available.y
-                val resistance = kotlin.math.sqrt(pullOffsetAnim.value / maxPull + 0.001f)
+                val resistance = kotlin.math.sqrt((rawPullOffset / maxPull).coerceAtLeast(0f) + 0.001f)
                 val damped = rawDelta * (1f - resistance * 0.6f)
-                val target = (pullOffsetAnim.value + damped).coerceIn(0f, maxPull)
-                coroutineScope.launch {
-                    pullOffsetAnim.snapTo(target)
-                    if (target >= pullThreshold && !isHapticTriggered) {
-                        isHapticTriggered = true
-                        performHaptic()
-                    }
-                }
+                val target = (rawPullOffset + damped).coerceIn(0f, maxPull)
+
+                rawPullOffset = target
                 return Offset(0f, available.y)
             }
             return Offset.Zero
         }
 
         override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-            if (!showKept && keptListSize() > 0 && pullOffsetAnim.value > 0f &&
+            if (!showKept && keptListSize() > 0 && rawPullOffset > 0f &&
                 available.y > 0f && source == NestedScrollSource.UserInput
             ) {
-                val consumed = available.y.coerceAtMost(pullOffsetAnim.value)
-                val target = pullOffsetAnim.value - consumed
-                coroutineScope.launch {
-                    pullOffsetAnim.snapTo(target)
-                    if (target < pullThreshold) {
-                        isHapticTriggered = false
-                    }
-                }
+                val consumed = available.y.coerceAtMost(rawPullOffset)
+                val target = rawPullOffset - consumed
+                rawPullOffset = target
                 return Offset(0f, consumed)
             }
             return Offset.Zero
         }
 
         override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-            if (!showKept && keptListSize() > 0) {
-                if (pullOffsetAnim.value >= pullThreshold) {
+            if (!showKept && keptListSize() > 0 && rawPullOffset > 0f) {
+                val initialOffset = rawPullOffset
+
+                if (initialOffset >= pullThreshold) {
                     showKept = true
-                    performHaptic()
-                } else {
-                    isReleasing = true
                 }
-                pullOffsetAnim.animateTo(
+
+                releaseAnim.snapTo(initialOffset)
+                isReleasing = true
+                rawPullOffset = 0f
+
+                releaseAnim.animateTo(
                     targetValue = 0f,
+                    initialVelocity = -available.y,
                     animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        dampingRatio = Spring.DampingRatioLowBouncy,
                         stiffness = Spring.StiffnessMediumLow
                     )
                 )
                 isReleasing = false
-                isHapticTriggered = false
             }
             return Velocity.Zero
         }
@@ -129,17 +123,9 @@ class NestedScrollPullToRevealState(
 @Composable
 fun rememberPullToRevealState(keptListSize: () -> Int): NestedScrollPullToRevealState {
     val scope = rememberCoroutineScope()
-    val view = LocalView.current
     return remember(keptListSize) {
         NestedScrollPullToRevealState(
             coroutineScope = scope,
-            performHaptic = {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                } else {
-                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                }
-            },
             keptListSize = keptListSize
         )
     }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/PullToKeptIndicator.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/PullToKeptIndicator.kt
@@ -158,11 +158,12 @@ fun PullToKeptIndicator(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            val formattedKept = dev.sj010.ssjanitor.ui.screens.home.common.formatCompactCount(keptCount)
             Text(
                 text = if (isReadyToRelease)
-                    "✓ Release to reveal $keptCount kept"
+                    "✓ Release to reveal $formattedKept kept"
                 else
-                    "Pull up to show $keptCount kept screenshot${if (keptCount > 1) "s" else ""}",
+                    "Pull up to show $formattedKept kept screenshot${if (keptCount > 1) "s" else ""}",
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.Bold,
                 color = if (isReadyToRelease)

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/PullToKeptIndicator.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/PullToKeptIndicator.kt
@@ -1,7 +1,6 @@
 package dev.sj010.ssjanitor.ui.screens.home.gesture
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.Spring
@@ -11,7 +10,6 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
@@ -44,20 +42,18 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 
 /**
  * A pull-to-reveal indicator shown at the bottom of the screenshot list.
- * Displays a circle with a chevron (or bookmark when ready), plus animated
- * text and a progress bar during active pulling.
+ * Displays a circle with a chevron (or bookmark when ready), plus text and progress bar.
+ * Uses fixed layout height and graphicsLayer transformations for 100% smooth gesture release.
  */
 @Composable
 fun PullToKeptIndicator(
+    pullOffset: Float,
     pullFraction: Float,
     isAtEnd: Boolean,
-    isPulling: Boolean,
-    isReleasing: Boolean,
     keptCount: Int,
     modifier: Modifier = Modifier
 ) {
     val isReadyToRelease = pullFraction >= 1f
-    val showPullText = isPulling && !isReleasing
 
     val indicatorAlpha by animateFloatAsState(
         targetValue = if (isAtEnd) 1f else 0f,
@@ -80,20 +76,13 @@ fun PullToKeptIndicator(
         label = "containerColor"
     )
 
-    val chevronRotation by animateFloatAsState(
-        targetValue = if (isPulling) pullFraction * 180f else 0f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessMedium
-        ),
-        label = "chevronRotation"
-    )
+    val chevronRotation = pullFraction * 180f
 
-    // Idle bounce hint: chevron gently floats up when at bottom, not pulling
+    // Idle bounce hint when at bottom and not pulling
     val infiniteTransition = rememberInfiniteTransition(label = "chevronBounce")
     val chevronBounce by infiniteTransition.animateFloat(
         initialValue = 0f,
-        targetValue = if (isAtEnd && !isPulling && !isReadyToRelease) -8f else 0f,
+        targetValue = if (isAtEnd && pullFraction == 0f) -8f else 0f,
         animationSpec = infiniteRepeatable(
             animation = tween(durationMillis = 700, easing = FastOutSlowInEasing),
             repeatMode = androidx.compose.animation.core.RepeatMode.Reverse
@@ -101,23 +90,31 @@ fun PullToKeptIndicator(
         label = "chevronBounceOffset"
     )
 
+    // Smooth text & progress opacity driven by pullFraction (no structural layout shift)
+    val textAlpha = (pullFraction / 0.25f).coerceIn(0f, 1f)
+
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 12.dp)
-            .graphicsLayer { alpha = indicatorAlpha },
+            .height(150.dp) // Fixed container height prevents layout resize jank on release
+            .padding(top = 28.dp, bottom = 12.dp)
+            .graphicsLayer {
+                alpha = indicatorAlpha
+                // Physical spring translation matching pull drag and release spring
+                translationY = -pullOffset * 0.25f
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         // Circle with icon (always visible at bottom)
         Box(
             modifier = Modifier
-                .size(56.dp)
+                .size(52.dp)
                 .clip(CircleShape)
                 .background(containerColor)
                 .graphicsLayer {
-                    scaleX = 1f + pullFraction * 0.15f
-                    scaleY = 1f + pullFraction * 0.15f
+                    scaleX = 1f + pullFraction * 0.12f
+                    scaleY = 1f + pullFraction * 0.12f
                 },
             contentAlignment = Alignment.Center
         ) {
@@ -155,49 +152,37 @@ fun PullToKeptIndicator(
             }
         }
 
-        // Text + progress — only appear during active pull
-        AnimatedVisibility(
-            visible = showPullText,
-            enter = fadeIn(
-                animationSpec = spring(Spring.DampingRatioNoBouncy, Spring.StiffnessMediumLow)
-            ) + expandVertically(
-                expandFrom = Alignment.Top,
-                animationSpec = spring(Spring.DampingRatioNoBouncy, Spring.StiffnessMediumLow)
-            ),
-            exit = fadeOut(
-                tween(durationMillis = 200)
-            )
+        // Text + progress bar (fades smoothly via graphicsLayer without layout jumps)
+        Column(
+            modifier = Modifier.graphicsLayer { alpha = textAlpha },
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                Text(
-                    text = if (isReadyToRelease)
-                        "✓ Release to reveal $keptCount kept"
-                    else
-                        "Pull up to show $keptCount kept screenshot${if (keptCount > 1) "s" else ""}",
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = if (isReadyToRelease)
-                        MaterialTheme.colorScheme.primary
-                    else
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Text(
+                text = if (isReadyToRelease)
+                    "✓ Release to reveal $keptCount kept"
+                else
+                    "Pull up to show $keptCount kept screenshot${if (keptCount > 1) "s" else ""}",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = if (isReadyToRelease)
+                    MaterialTheme.colorScheme.primary
+                else
+                    MaterialTheme.colorScheme.onSurfaceVariant
+            )
 
-                LinearProgressIndicator(
-                    progress = { pullFraction },
-                    modifier = Modifier
-                        .width(160.dp)
-                        .height(5.dp)
-                        .clip(CircleShape),
-                    color = if (isReadyToRelease)
-                        MaterialTheme.colorScheme.primary
-                    else
-                        MaterialTheme.colorScheme.secondary,
-                    trackColor = MaterialTheme.colorScheme.surfaceVariant
-                )
-            }
+            LinearProgressIndicator(
+                progress = { pullFraction },
+                modifier = Modifier
+                    .width(160.dp)
+                    .height(5.dp)
+                    .clip(CircleShape),
+                color = if (isReadyToRelease)
+                    MaterialTheme.colorScheme.primary
+                else
+                    MaterialTheme.colorScheme.secondary,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/stats/StatsGrid.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/stats/StatsGrid.kt
@@ -135,6 +135,7 @@ fun StatsGrid(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier.fillMaxWidth(),
+                    onClick = onKeptLongClick,
                     onLongClick = onKeptLongClick
                 )
                 if (showKept && uiState.keptCount > 0) {
@@ -182,13 +183,14 @@ fun StatsCard(
     containerColor: Color,
     contentColor: Color,
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null
 ) {
     Card(
         modifier = modifier.then(
-            if (onLongClick != null) {
+            if (onClick != null || onLongClick != null) {
                 Modifier.combinedClickable(
-                    onClick = {},
+                    onClick = onClick ?: {},
                     onLongClick = onLongClick
                 )
             } else Modifier


### PR DESCRIPTION
## Summary
- **Gesture Optimization**: Replaced 120Hz coroutine dispatches in touch scroll processing (`onPostScroll`/`onPreScroll`) with direct float state updates (`rawPullOffset`), eliminating input latency spikes and coroutine object allocation churn.
- **Fluid Spring Release**: Removed `Modifier.animateItem()` and structural height expand/collapse from `PullToKeptIndicator`, using `graphicsLayer` translation & alpha for 100% smooth 60fps spring release animations without layout jumps.
- **Compact Count Formatting**: Updated stats cards (Pending, Archived, Kept, Cleaned), section headers, and counters to format counts 1000+ into compact `1K`, `1.5K`, `10K`, `1.2M`, `1B` notation.
- **Stat Card Navigation**: Tapping or long-pressing the **Kept** stat card now reveals the kept screenshots list and smoothly animates the scroll position directly to the **Kept Screenshots** header.
- **Version Bump**: Bumped version to `1.1.2` (versionCode `10`) and updated `CHANGELOG.md`.