### PR TITLE
chore: bump version to 1.1.3 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.3] - 2026-08-13
+
+### Added
+- **Drag haptic feedback** — Added 40px drag tick haptic feedback during pull-to-reveal gesture and restored `CONFIRM` threshold feedback when crossing the trigger limit.
+- **Auto Mode off heads-up notification** — Added heads-up notification when Auto Mode / Janitor background detection is toggled off.
+
 ## [1.1.2] - 2026-08-11
 
 ### Performance

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         applicationId = "dev.sj010.ssjanitor"
         minSdk = 34
         targetSdk = 36
-        versionCode = 10
-        versionName = "1.1.2"
+        versionCode = 11
+        versionName = "1.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Bumps app version to 1.1.3 (versionCode 11) and updates CHANGELOG.md.