### PR TITLE
fix: hold gesture on Kept stat card, haptic refinement & thumbnail preview reload fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.1.3] - 2026-08-13
 
 ### Added
-- **Drag haptic feedback** — Added 40px drag tick haptic feedback during pull-to-reveal gesture and restored `CONFIRM` threshold feedback when crossing the trigger limit.
+- **Pull threshold haptic feedback** — Restored `CONFIRM` threshold feedback when crossing the trigger limit during pull-to-reveal gesture.
 - **Auto Mode off heads-up notification** — Added heads-up notification when Auto Mode / Janitor background detection is toggled off.
 
 ## [1.1.2] - 2026-08-11

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeContent.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/HomeContent.kt
@@ -108,7 +108,10 @@ fun HomeContent(
     // True once user has scrolled all the way to the bottom
     val isAtBottom by remember {
         derivedStateOf {
-            !listState.canScrollForward
+            val info = listState.layoutInfo
+            val lastVisible = info.visibleItemsInfo.lastOrNull()
+            lastVisible != null && lastVisible.index == info.totalItemsCount - 1 &&
+                    lastVisible.offset + lastVisible.size <= info.viewportEndOffset
         }
     }
 
@@ -241,6 +244,7 @@ fun HomeContent(
                 EmptyStateView(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .fillParentMaxHeight(0.5f)
                         .padding(vertical = 8.dp)
                 )
             }
@@ -312,7 +316,6 @@ fun HomeContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 24.dp)
-                            .animateItem()
                     )
                 }
             }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/common/EmptyStateView.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/common/EmptyStateView.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -132,15 +133,14 @@ private fun ArchiveBoxAnimation(modifier: Modifier = Modifier) {
     val containerColor = MaterialTheme.colorScheme.secondaryContainer
     val boxBackgroundColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val boxIconColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f)
-
     val glyphStates = remember { glyphSpecs.map { GlyphState() } }
-
     val smoothTime = remember { mutableFloatStateOf(0f) }
 
     LaunchedEffect(Unit) {
         while (true) {
-            delay(16)
-            smoothTime.floatValue += 0.016f
+            withFrameNanos { frameTimeNanos ->
+                smoothTime.floatValue = frameTimeNanos / 1_000_000_000f
+            }
         }
     }
 

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/NestedScrollPullToRevealState.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/NestedScrollPullToRevealState.kt
@@ -23,9 +23,6 @@ import kotlinx.coroutines.CoroutineScope
  * Types of haptic feedback emitted during the pull-to-reveal gesture flow.
  */
 enum class DragHapticType {
-    /** Subtle 40px step tick vibration while dragging. */
-    DragTick,
-
     /** Haptic feedback when pull crosses the threshold to trigger. */
     ThresholdActivate,
 
@@ -40,7 +37,7 @@ enum class DragHapticType {
  * Encapsulates the pull-to-reveal gesture logic for revealing "Kept" screenshots.
  *
  * Uses a rubber-band damped pull that resists harder the further you drag,
- * with Material 3 haptic drag ticks every 40px and a spring-back animation on release.
+ * with Material 3 haptic threshold feedback and a spring-back animation on release.
  */
 class NestedScrollPullToRevealState(
     private val coroutineScope: CoroutineScope,
@@ -58,8 +55,6 @@ class NestedScrollPullToRevealState(
     var isReleasing by mutableStateOf(false)
 
     private var isHapticTriggered by mutableStateOf(false)
-    private var lastTickStep = 0
-    private val tickStepDistance = 40f
 
     // True once user has scrolled all the way to the bottom of pending+achieved
     private var isAtBottomFn: (() -> Boolean)? = null
@@ -87,12 +82,6 @@ class NestedScrollPullToRevealState(
 
                 rawPullOffset = target
 
-                val currentStep = (target / tickStepDistance).toInt()
-                if (target < pullThreshold && currentStep != lastTickStep && target > 0f) {
-                    lastTickStep = currentStep
-                    performHaptic(DragHapticType.DragTick)
-                }
-
                 if (target >= pullThreshold && !isHapticTriggered) {
                     isHapticTriggered = true
                     performHaptic(DragHapticType.ThresholdActivate)
@@ -110,12 +99,6 @@ class NestedScrollPullToRevealState(
                 val consumed = available.y.coerceAtMost(rawPullOffset)
                 val target = rawPullOffset - consumed
                 rawPullOffset = target
-
-                val currentStep = (target / tickStepDistance).toInt()
-                if (target < pullThreshold && currentStep != lastTickStep && target > 0f) {
-                    lastTickStep = currentStep
-                    performHaptic(DragHapticType.DragTick)
-                }
 
                 if (target < pullThreshold && isHapticTriggered) {
                     isHapticTriggered = false
@@ -150,7 +133,6 @@ class NestedScrollPullToRevealState(
                 )
                 isReleasing = false
                 isHapticTriggered = false
-                lastTickStep = 0
             }
             return Velocity.Zero
         }
@@ -181,13 +163,6 @@ fun rememberPullToRevealState(keptListSize: () -> Int): NestedScrollPullToReveal
             coroutineScope = scope,
             performHaptic = { hapticType ->
                 when (hapticType) {
-                    DragHapticType.DragTick -> {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                            view.performHapticFeedback(HapticFeedbackConstants.SEGMENT_TICK)
-                        } else {
-                            view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
-                        }
-                    }
                     DragHapticType.ThresholdActivate -> {
                         view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                     }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/PullToKeptIndicator.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/gesture/PullToKeptIndicator.kt
@@ -79,13 +79,11 @@ fun PullToKeptIndicator(
     val chevronRotation = pullFraction * 180f
 
     // Idle bounce hint when at bottom and not pulling
-    val infiniteTransition = rememberInfiniteTransition(label = "chevronBounce")
-    val chevronBounce by infiniteTransition.animateFloat(
-        initialValue = 0f,
+    val chevronBounce by animateFloatAsState(
         targetValue = if (isAtEnd && pullFraction == 0f) -8f else 0f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 700, easing = FastOutSlowInEasing),
-            repeatMode = androidx.compose.animation.core.RepeatMode.Reverse
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
         ),
         label = "chevronBounceOffset"
     )

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotCard.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.sj010.ssjanitor.data.db.entity.ScreenshotEntity
+import androidx.compose.ui.graphics.compositeOver
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -49,10 +50,17 @@ fun ScreenshotCard(
     onRelease: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    val cardColor = when {
-        screenshot.kept -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
-        screenshot.archived -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.55f)
-        else -> MaterialTheme.colorScheme.surfaceContainer
+    val surface = MaterialTheme.colorScheme.surface
+    val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+    val tertiaryContainer = MaterialTheme.colorScheme.tertiaryContainer
+    val surfaceContainer = MaterialTheme.colorScheme.surfaceContainer
+
+    val cardColor = remember(screenshot.kept, screenshot.archived, surface, primaryContainer, tertiaryContainer, surfaceContainer) {
+        when {
+            screenshot.kept -> primaryContainer.copy(alpha = 0.55f).compositeOver(surface)
+            screenshot.archived -> tertiaryContainer.copy(alpha = 0.55f).compositeOver(surface)
+            else -> surfaceContainer
+        }
     }
 
     Card(

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotPreviewOverlay.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotPreviewOverlay.kt
@@ -74,13 +74,12 @@ fun ScreenshotPreviewOverlay(
     if (uriString != null) lastUri = uriString
     val uri = lastUri
 
-    var bitmap by remember(uri) { mutableStateOf<Bitmap?>(null) }
+    var bitmap by remember { mutableStateOf<Bitmap?>(null) }
     val context = LocalContext.current
     val density = LocalDensity.current
 
-    LaunchedEffect(uri) {
-        bitmap = null
-        if (uri != null) {
+    LaunchedEffect(uri, visible) {
+        if (visible && uri != null) {
             bitmap = loadPreviewBitmap(context, Uri.parse(uri))
         }
     }

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotPreviewOverlay.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotPreviewOverlay.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -106,6 +107,15 @@ fun ScreenshotPreviewOverlay(
             // cut straight to the clear thumbnail.
             delay(100)
             isRendered = false
+        }
+    }
+
+    DisposableEffect(isRendered) {
+        onDispose {
+            if (!isRendered) {
+                bitmap?.recycle()
+                bitmap = null
+            }
         }
     }
 

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotThumbnail.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/screenshot/ScreenshotThumbnail.kt
@@ -217,7 +217,7 @@ fun ScreenshotThumbnail(
 
         // Hold-delay blur cue: fades in while the user holds, fades back out on
         // release. Sits above the artwork so the thumbnail appears to blur over.
-        if (bitmap != null) {
+        if (bitmap != null && blurAlpha.value > 0f) {
             Image(
                 bitmap = bitmap!!.asImageBitmap(),
                 contentDescription = null,

--- a/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/stats/StatsGrid.kt
+++ b/app/src/main/java/dev/sj010/ssjanitor/ui/screens/home/stats/StatsGrid.kt
@@ -135,7 +135,6 @@ fun StatsGrid(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier.fillMaxWidth(),
-                    onClick = onKeptLongClick,
                     onLongClick = onKeptLongClick
                 )
                 if (showKept && uiState.keptCount > 0) {


### PR DESCRIPTION
## What does this PR do?

This PR addresses several UI, gesture, and preview interaction fixes:
1. **Thumbnail Preview Reload Fix**: Fixed an issue in `ScreenshotPreviewOverlay` where `LaunchedEffect` was keyed solely on `uri`, preventing bitmap reloads on repeated hold attempts on the same thumbnail after the previous preview bitmap was disposed. Now keyed on `(uri, visible)`.
2. **Kept Stat Card Hold Gesture**: Requires a hold gesture on the Kept stat card to toggle the SHOWN state and reveal the Kept screenshots list.
3. **Pull-to-Reveal Haptics Refinement**: Removed the drag tick haptic feedback during pull-to-reveal gestures to keep haptics focused on trigger limits.
4. **UI & Color Compositing**: Composited card container colors and applied overscroll & rendering stability adjustments.

## Related issue

None

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor / chore / docs

## How has this been tested?

- [x] `./gradlew lint`
- [x] `./gradlew test`
- [x] Manual verification on device/emulator (API level: 34 / Android 14)

## Checklist

- [x] My code follows the project style and builds cleanly
- [x] I have added/updated tests where appropriate
- [ ] I have updated `CHANGELOG.md` (for user-facing changes)